### PR TITLE
Fix build. Add missing include (fuzzing-headers/include/).

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,7 @@ project (examples)
 
 include_directories(../include/)
 include_directories(../libvfuzz-core/src)
+include_directories(../third_party/fuzzing-headers/include/)
 
 add_executable(nlohmann nlohmann.cpp)
 set_target_properties(nlohmann PROPERTIES COMPILE_FLAGS -fsanitize-coverage=trace-pc-guard)


### PR DESCRIPTION
Fix build. Add missing include (`fuzzing-headers/include/`).

Before this patch:

```
$ git clone https://github.com/guidovranken/vfuzz
$ cd vfuzz/
$ mkdir build/
$ cd build/
$ cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
$ make -j $(nproc)
…
[ 97%] Building CXX object examples/CMakeFiles/nlohmann.dir/nlohmann.cpp.o
vfuzz/examples/../include/vfuzz/datasource.h:3:10: fatal error: 'fuzzing/datasource/datasource.hpp' file not found
vfuzz/examples/../include/vfuzz/types.h:5:10: fatal error: 'fuzzing/datasource/id.hpp' file not found
$ echo $?
2
```

After this patch:

```
$ git clone https://github.com/guidovranken/vfuzz
$ cd vfuzz/
$ mkdir build/
$ cd build/
$ cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
$ make -j $(nproc)
…
[ 97%] Building CXX object examples/CMakeFiles/nlohmann.dir/nlohmann.cpp.o
[ 98%] Linking CXX executable libvfuzz-core-example
[ 98%] Built target libvfuzz-core-example
[100%] Linking CXX executable nlohmann
[100%] Built target nlohmann
$ echo $?
0
```

